### PR TITLE
Add Arduino IDE required fields to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,10 +1,12 @@
 name=New_Ping
 version=1.8.0
 author=Tim Eckel
+maintainer=eliteio
+sentence=A library that makes working with ultrasonic sensors easy.
+paragraph=When I first received an ultrasonic sensor I was not happy with how poorly it performed. I soon realized the problem was not the sensor, it was the available ping and ultrasonic libraries causing the problem. The NewPing library totally fixes these problems, adds many new features, and breathes new life into these very affordable distance sensors.
+category=Sensors
+url=https://github.com/eliteio/Arduino_New_Ping
 # license=insert your choice of license here
-# sentence=one sentence description of this library
-# paragraph=a longer description of this library, always prepended with sentence when shown
-# url=the URL of the project, like https://github.com/mygithub_user/my_repo
 # repository=git repository for the project, like https://github.com/mygithub_user/my_repo.git
 # architectures=a list of supported boards if this library is hardware dependent, like particle-photon,particle-electron
 dependencies.SparkIntervalTimer=1.3.7


### PR DESCRIPTION
When a required field is missing from library.properties the Arduino IDE does not recognize the library:

- Sketch > Include Library > Add .ZIP Library fails silently.
- Compilation of any code that includes the library fails.
- After manual installation, "Invalid library" warnings are shown every time the libraries are scanned.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format